### PR TITLE
Fix UnicodeDecodeError when uploading binary files

### DIFF
--- a/src/denario_app/components.py
+++ b/src/denario_app/components.py
@@ -31,11 +31,14 @@ def description_comp(den: Denario) -> None:
         height=100
     )
 
-    uploaded_file = st.file_uploader("Alternatively, upload a file with the data description in markdown format.", accept_multiple_files=False)
+    uploaded_file = st.file_uploader("Alternatively, upload a file with the data description in markdown format.", accept_multiple_files=False, type=["md", "txt"])
 
     if uploaded_file:
-        content = uploaded_file.read().decode("utf-8")
-        den.set_data_description(content)   
+        try:
+            content = uploaded_file.read().decode("utf-8")
+            den.set_data_description(content)
+        except UnicodeDecodeError:
+            st.error("Unable to read file. Please upload a valid markdown (.md) or text (.txt) file.")   
 
     if data_descr:
 
@@ -255,11 +258,14 @@ def idea_comp(den: Denario) -> None:
                 finally:
                     st.session_state.idea_running = False
 
-    uploaded_file = st.file_uploader("Choose a file with the research idea", accept_multiple_files=False)
+    uploaded_file = st.file_uploader("Choose a file with the research idea", accept_multiple_files=False, type=["md", "txt"])
 
     if uploaded_file:
-        content = uploaded_file.read().decode("utf-8")
-        den.set_idea(content)
+        try:
+            content = uploaded_file.read().decode("utf-8")
+            den.set_idea(content)
+        except UnicodeDecodeError:
+            st.error("Unable to read file. Please upload a valid markdown (.md) or text (.txt) file.")
 
     try:
         show_markdown_file(den.project_dir+"/input_files/idea.md", extra_format=True, label="idea")
@@ -396,11 +402,14 @@ def method_comp(den: Denario) -> None:
                 finally:
                     st.session_state.method_running = False
 
-    uploaded_file = st.file_uploader("Choose a file with the research methods", accept_multiple_files=False)
+    uploaded_file = st.file_uploader("Choose a file with the research methods", accept_multiple_files=False, type=["md", "txt"])
 
     if uploaded_file:
-        content = uploaded_file.read().decode("utf-8")
-        den.set_method(content)
+        try:
+            content = uploaded_file.read().decode("utf-8")
+            den.set_method(content)
+        except UnicodeDecodeError:
+            st.error("Unable to read file. Please upload a valid markdown (.md) or text (.txt) file.")
 
     try:
         show_markdown_file(den.project_dir+"/input_files/methods.md",label="methods")
@@ -553,8 +562,11 @@ def results_comp(den: Denario) -> None:
         plots = []
         for file in uploaded_files:
             if file.name.endswith(".md"):
-                content = file.read().decode("utf-8")
-                den.set_results(content)
+                try:
+                    content = file.read().decode("utf-8")
+                    den.set_results(content)
+                except UnicodeDecodeError:
+                    st.error(f"Unable to read {file.name}. Please ensure it's a valid UTF-8 encoded markdown file.")
             else:
                 plots.append(Image.open(file))
         den.set_plots(plots)


### PR DESCRIPTION
## Summary
- Fix crash when users accidentally upload PDF or other binary files instead of markdown
- Add file type restrictions to file uploaders (`.md`, `.txt` only)
- Add try-except handling with user-friendly error messages

## Problem
When a user uploads a PDF or other binary file to the file uploaders in components.py, the app crashes with:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbf in position 10: invalid start byte
```

## Solution
1. Restrict file uploaders to accept only `.md` and `.txt` files using Streamlit's `type` parameter
2. Wrap decode operations in try-except to catch any remaining encoding issues
3. Display friendly error message instead of crashing

## Affected Functions
- `description_comp`: line 34-41
- `idea_comp`: line 261-268
- `method_comp`: line 405-412
- `results_comp`: line 564-569

## Test Plan
- [ ] Upload a `.md` file - should work as before
- [ ] Upload a `.txt` file - should work
- [ ] Attempt to upload a `.pdf` file - should be blocked by file type filter
- [ ] Upload a malformed text file - should show friendly error

🤖 Generated with [Claude Code](https://claude.com/claude-code)